### PR TITLE
Add AddToolDto and update tool addition logic

### DIFF
--- a/Application/Dto/ToolDtos/AddToolDto.cs
+++ b/Application/Dto/ToolDtos/AddToolDto.cs
@@ -1,0 +1,17 @@
+﻿using Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Dto.ToolDtos
+{
+	public class AddToolDto
+	{
+		public string Name { get; set; } = null!;
+		public string? Description { get; set; }
+		public Guid CategoryId { get; set; }
+		public ToolStatus Status { get; set; } = ToolStatus.Available;
+	}
+}

--- a/Application/Mappings/MappingProfile.cs
+++ b/Application/Mappings/MappingProfile.cs
@@ -16,6 +16,10 @@ namespace Application.Mappings
 
 			CreateMap<UpdateToolDto, Tool>()
 				.ForMember(dest => dest.Category, opt => opt.Ignore());
+			CreateMap<AddToolDto, Tool>()
+				.ForMember(dest => dest.Category, opt => opt.Ignore())
+				.ForMember(dest => dest.Status, opt => opt.MapFrom(src => ToolStatus.Available));
+
 		}
 	}
 }

--- a/Application/Services/Interfaces/IToolService.cs
+++ b/Application/Services/Interfaces/IToolService.cs
@@ -7,7 +7,7 @@ namespace Application.Services.Interfaces
 {
 	public interface IToolService
 	{
-		Task AddAsync(ToolDto toolDto, CancellationToken ct = default);
+		Task<Guid?> AddAsync(AddToolDto addToolDto, CancellationToken ct = default);
 		Task UpdateAsync(UpdateToolDto toolDto, Guid toolId, CancellationToken ct = default);
 		Task DeleteAsync(Guid id, CancellationToken ct = default);
 		Task<ApiResponse<ToolDto?>> GetByIdAsync(Guid id, CancellationToken ct = default);

--- a/Application/Validators/AddToolDtoValidator.cs
+++ b/Application/Validators/AddToolDtoValidator.cs
@@ -1,0 +1,29 @@
+﻿using Application.Dto.ToolDtos;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Validators
+{
+	public class AddToolDtoValidator : AbstractValidator<AddToolDto>
+	{
+		public AddToolDtoValidator()
+		{
+			RuleFor(x => x.Name)
+			.NotEmpty().WithMessage("Name is required")
+			.MaximumLength(100).WithMessage("Name cannot exceed 100 characters");
+
+			RuleFor(x => x.Description)
+				.MaximumLength(500).WithMessage("Description cannot exceed 500 characters");
+
+			RuleFor(x => x.CategoryId)
+				.NotEmpty().WithMessage("Category is required");
+
+			RuleFor(x => x.Status)
+				.NotNull().WithMessage("Availability status is required");
+		}
+	}
+}

--- a/Domain/Interfaces/Repositories/IToolRepository.cs
+++ b/Domain/Interfaces/Repositories/IToolRepository.cs
@@ -7,7 +7,7 @@ namespace Domain.Interfaces.Repositories
 		// Basic CRUD
 		Task<Tool?> GetByIdAsync(Guid id, CancellationToken ct = default);
 		Task<IEnumerable<Tool>> GetAllAsync(CancellationToken ct = default);
-		Task AddAsync(Tool tool, CancellationToken ct = default);
+		Task<Guid?> AddAsync(Tool tool, CancellationToken ct = default);
 		Task UpdateAsync(Tool tool, CancellationToken ct = default);
 		Task DeleteAsync(Tool tool, CancellationToken ct = default);
 

--- a/Infrastructure/Repositories/ToolRepository.cs
+++ b/Infrastructure/Repositories/ToolRepository.cs
@@ -16,9 +16,10 @@ namespace Infrastructure.Repositories
 			_context = context;
 		}
 
-		public async Task AddAsync(Tool tool, CancellationToken ct)
+		public async Task<Guid?> AddAsync(Tool tool, CancellationToken ct)
 		{
-			await _context.Tools.AddAsync(tool, ct);
+			var addedTool = await _context.Tools.AddAsync(tool, ct);
+			return addedTool.Entity.Id;
 		}
 
 		public Task DeleteAsync(Tool tool, CancellationToken ct)

--- a/TooliRent/Controllers/ToolsController.cs
+++ b/TooliRent/Controllers/ToolsController.cs
@@ -35,6 +35,15 @@ namespace TooliRent.Controllers
 			var tool = await _toolService.GetByIdAsync(id, ct);
 			return Ok(tool);
 		}
+		[HttpPost]
+		public async Task<ActionResult<ApiResponse<ToolDto>>> AddTool([FromBody] AddToolDto addToolDto, CancellationToken ct)
+		{
+			var toolId = await _toolService.AddAsync(addToolDto, ct);
+			var toolDto = await _toolService.GetByIdAsync(toolId.Value, ct);
+			toolDto.Message = "Tool created successfully"; // Set the correct message for creation
+			return CreatedAtAction(nameof(GetToolById), new { id = toolId }, toolDto);
+
+		}
 		[HttpGet("avalible")]
 		public async Task<ActionResult<ApiResponse<IEnumerable<ToolDto>>>> GetAvalibleTools(CancellationToken ct)
 		{


### PR DESCRIPTION
Introduces a new Data Transfer Object (DTO) `AddToolDto` for adding tools, including properties for name, description, category ID, and status. Updates the `IToolService` interface to replace the existing `AddAsync` method with one that accepts `AddToolDto` and returns a nullable `Guid`.

Implements validation in the `ToolService` for category existence before adding a tool, and modifies the `ToolRepository` to return the ID of the added tool. Adds a new endpoint in `ToolsController` for tool creation and introduces `AddToolDtoValidator` for input validation. Updates `MappingProfile.cs` to map `AddToolDto` to `Tool`, ignoring the category and setting the status to `ToolStatus.Available`.