### PR TITLE
Add booking DTO validators for validation rules

### DIFF
--- a/Application/Validators/AddBookingDtoValidator.cs
+++ b/Application/Validators/AddBookingDtoValidator.cs
@@ -1,0 +1,25 @@
+﻿using Application.Dto.BookingDtos;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Validators
+{
+	public class AddBookingDtoValidator : AbstractValidator<AddBookingDto>
+	{
+		public AddBookingDtoValidator()
+		{
+			RuleFor(x => x.ToolIds)
+				.NotEmpty().WithMessage("At least one tool must be selected.");
+
+			RuleFor(x => x.StartAt)
+				.GreaterThanOrEqualTo(DateTime.UtcNow).WithMessage("Start date must be in the future.");
+
+			RuleFor(x => x.EndAt)
+				.GreaterThan(x => x.StartAt).WithMessage("End date must be after start date.");
+		}
+	}
+}

--- a/Application/Validators/UpdateBookingDtoValidator.cs
+++ b/Application/Validators/UpdateBookingDtoValidator.cs
@@ -1,0 +1,23 @@
+﻿using Application.Dto.BookingDtos;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Validators
+{
+	public class UpdateBookingDtoValidator : AbstractValidator<UpdateBookingDto>
+	{
+		public UpdateBookingDtoValidator()
+		{
+
+			RuleFor(x => x.Status)
+				.IsInEnum().WithMessage("Invalid status value.");
+
+			RuleFor(x => x.EndAt)
+				.GreaterThan(x => x.StartAt).WithMessage("End date must be after start date.");
+		}
+	}
+}


### PR DESCRIPTION
Implemented `AddBookingDtoValidator` to ensure at least one tool is selected, the start date is in the future, and the end date is after the start date. Added `UpdateBookingDtoValidator` to validate status as a valid enum and ensure the end date is after the start date.